### PR TITLE
Security update of inch

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     inch_by_inch (1.0.0)
-      inch (~> 0.7.0)
+      inch (~> 0.8.0)
       rake (~> 10.0)
 
 GEM
@@ -11,22 +11,21 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    coderay (1.1.0)
-    inch (0.7.0)
+    coderay (1.1.2)
+    inch (0.8.0)
       pry
       sparkr (>= 0.2.0)
       term-ansicolor
-      yard (~> 0.8.7.5)
-    method_source (0.8.2)
+      yard (~> 0.9.12)
+    method_source (0.9.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
-    pry (0.10.3)
+    pry (0.11.3)
       coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
+      method_source (~> 0.9.0)
     rainbow (2.0.0)
-    rake (10.4.2)
+    rake (10.5.0)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -35,12 +34,11 @@ GEM
       ruby-progressbar (~> 1.7)
       tins (<= 1.6.0)
     ruby-progressbar (1.7.5)
-    slop (3.6.0)
     sparkr (0.4.1)
-    term-ansicolor (1.3.2)
+    term-ansicolor (1.6.0)
       tins (~> 1.0)
     tins (1.6.0)
-    yard (0.8.7.6)
+    yard (0.9.12)
 
 PLATFORMS
   ruby
@@ -51,4 +49,4 @@ DEPENDENCIES
   rubocop
 
 BUNDLED WITH
-   1.11.0.pre.2
+   1.16.1

--- a/inch_by_inch.gemspec
+++ b/inch_by_inch.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency 'inch', '~> 0.7.0'
+  spec.add_runtime_dependency 'inch', '~> 0.8.0'
   spec.add_runtime_dependency 'rake', '~> 10.0'
 
   spec.add_development_dependency 'bundler', '~> 1.11.pre'


### PR DESCRIPTION
@segiddins @mrackwitz 

In https://github.com/rrrene/inch/issues/42, Jesterovskiy reports
> a known high severity security vulnerability in version range < 0.9.11 and should be updated. https://nvd.nist.gov/vuln/detail/CVE-2017-17042

This is fixed in *inch* 0.8.0, released on April 11, 2018.
