### PR TITLE
Upgrade to Bundler 2.2 and remove version constraint of rake

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,10 @@
 inherit_from:
   - .rubocop_cocoapods.yml
   - .rubocop_todo.yml
+
+AllCops:
+  TargetRubyVersion: 2.6
+  # RuboCop has a bunch of cops enabled by default. This setting tells RuboCop
+  # to ignore them, so only the ones explicitly set in this file are enabled.
+  DisabledByDefault: true
+  SuggestExtensions: false

--- a/.rubocop_cocoapods.yml
+++ b/.rubocop_cocoapods.yml
@@ -1,58 +1,73 @@
+require:
+  - rubocop-performance
+
 AllCops:
   Include:
-    - ./Rakefile
-    - ./Gemfile
-    - ./*.gemspec
+    - lib/**/*.rb
+    - spec/**/*.rb
+    - Rakefile
+    - Gemfile
+    - "*.gemspec"
   Exclude:
-    - ./spec/fixtures/**/*
-    - ./vendor/bundle/**/*
+    - spec/fixtures/**/*
+    - vendor/bundle/**/*
 
 # At the moment not ready to be used
 # https://github.com/bbatsov/rubocop/issues/947
-Documentation:
+Style/Documentation:
   Enabled: false
 
 #- CocoaPods -----------------------------------------------------------------#
 
 # We adopted raise instead of fail.
-SignalException:
+Style/SignalException:
   EnforcedStyle: only_raise
 
 # They are idiomatic
-AssignmentInCondition:
+Lint/AssignmentInCondition:
   Enabled: false
 
 # Allow backticks
-AsciiComments:
+Style/AsciiComments:
   Enabled: false
 
 # Indentation clarifies logic branches in implementations
-IfUnlessModifier:
+Style/IfUnlessModifier:
   Enabled: false
 
 # No enforced convention here.
-SingleLineBlockParams:
+Style/SingleLineBlockParams:
   Enabled: false
 
 # We only add the comment when needed.
-Encoding:
+Style/Encoding:
   Enabled: false
 
 # Having these make it easier to *not* forget to add one when adding a new
 # value and you can simply copy the previous line.
-TrailingComma:
+Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-Style/MultilineOperationIndentation:
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+
+Layout/MultilineOperationIndentation:
   EnforcedStyle: indented
 
 # Clashes with CLAide Command#validate!
-GuardClause:
+Style/GuardClause:
   Enabled: false
 
 # Not always desirable: lib/claide/command/plugins_helper.rb:12:15
-Next:
+Style/Next:
   Enabled: false
+
+# Autocorrect makes this cop much more useful, taking away needless guessing
+Layout/EndAlignment:
+  AutoCorrect: true
 
 # Arbitrary max lengths for classes simply do not work and enabling this will
 # lead to a never ending stream of annoyance and changes.
@@ -90,16 +105,16 @@ Metrics/PerceivedComplexity:
 
 #- CocoaPods support for Ruby 1.8.7 ------------------------------------------#
 
-HashSyntax:
+Style/HashSyntax:
   EnforcedStyle: hash_rockets
 
-Lambda:
+Style/Lambda:
   Enabled: false
 
-DotPosition:
+Layout/DotPosition:
   EnforcedStyle: trailing
 
-EachWithObject:
+Style/EachWithObject:
   Enabled: false
 
 Style/SpecialGlobalVars:
@@ -108,19 +123,23 @@ Style/SpecialGlobalVars:
 #- CocoaPods specs -----------------------------------------------------------#
 
 # Allow for `should.match /regexp/`.
-AmbiguousRegexpLiteral:
+Lint/AmbiguousRegexpLiteral:
+  Exclude:
+    - spec/**/*
+
+Performance/RedundantMatch:
   Exclude:
     - spec/**/*
 
 # Allow `object.should == object` syntax.
-Void:
+Lint/Void:
   Exclude:
     - spec/**/*
 
-ClassAndModuleChildren:
+Style/ClassAndModuleChildren:
   Exclude:
     - spec/**/*
 
-UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Exclude:
     - spec/**/*

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Lint/NestedMethodDefinition:
 
 # Offense count: 5
 # Configuration parameters: AllowURI, URISchemes.
-Metrics/LineLength:
+Layout/LineLength:
   Max: 129
 
 # Offense count: 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ branches:
   only:
     - master
 rvm:
-  - 2.2
+  - 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,6 @@ source 'https://rubygems.org'
 gemspec
 
 group :development do
-  gem 'rubocop'
+  gem 'rubocop', '~> 1.8', :require => false
+  gem 'rubocop-performance', :require => false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,9 +8,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    ast (2.1.0)
-    astrolabe (1.3.1)
-      parser (~> 2.2)
+    ast (2.4.2)
     coderay (1.1.3)
     inch (0.8.0)
       pry
@@ -18,26 +16,38 @@ GEM
       term-ansicolor
       yard (~> 0.9.12)
     method_source (1.0.0)
-    parser (2.2.3.0)
-      ast (>= 1.1, < 3.0)
-    powerpack (0.1.1)
+    parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (2.0.0)
+    rainbow (3.0.0)
     rake (13.0.3)
-    rubocop (0.35.1)
-      astrolabe (~> 1.3)
-      parser (>= 2.2.3.0, < 3.0)
-      powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+    regexp_parser (2.0.3)
+    rexml (3.2.4)
+    rubocop (1.9.1)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
       ruby-progressbar (~> 1.7)
-      tins (<= 1.6.0)
-    ruby-progressbar (1.7.5)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
+    rubocop-performance (1.9.2)
+      rubocop (>= 0.90.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
+    ruby-progressbar (1.11.0)
     sparkr (0.4.1)
+    sync (0.5.0)
     term-ansicolor (1.7.1)
       tins (~> 1.0)
-    tins (1.6.0)
+    tins (1.28.0)
+      sync
+    unicode-display_width (2.0.0)
     yard (0.9.26)
 
 PLATFORMS
@@ -45,7 +55,8 @@ PLATFORMS
 
 DEPENDENCIES
   inch_by_inch!
-  rubocop
+  rubocop (~> 1.8)
+  rubocop-performance
 
 BUNDLED WITH
    2.2.8

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     inch_by_inch (1.0.1)
-      inch (~> 0.8.0)
-      rake (~> 10.0)
+      inch (~> 0.8)
+      rake
 
 GEM
   remote: https://rubygems.org/
@@ -11,21 +11,21 @@ GEM
     ast (2.1.0)
     astrolabe (1.3.1)
       parser (~> 2.2)
-    coderay (1.1.2)
+    coderay (1.1.3)
     inch (0.8.0)
       pry
       sparkr (>= 0.2.0)
       term-ansicolor
       yard (~> 0.9.12)
-    method_source (0.9.0)
+    method_source (1.0.0)
     parser (2.2.3.0)
       ast (>= 1.1, < 3.0)
     powerpack (0.1.1)
-    pry (0.11.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rainbow (2.0.0)
-    rake (10.5.0)
+    rake (13.0.3)
     rubocop (0.35.1)
       astrolabe (~> 1.3)
       parser (>= 2.2.3.0, < 3.0)
@@ -35,18 +35,17 @@ GEM
       tins (<= 1.6.0)
     ruby-progressbar (1.7.5)
     sparkr (0.4.1)
-    term-ansicolor (1.6.0)
+    term-ansicolor (1.7.1)
       tins (~> 1.0)
     tins (1.6.0)
-    yard (0.9.12)
+    yard (0.9.26)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.11.pre)
   inch_by_inch!
   rubocop
 
 BUNDLED WITH
-   1.16.1
+   2.2.8

--- a/inch_by_inch.gemspec
+++ b/inch_by_inch.gemspec
@@ -18,8 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.0.0'
-
   spec.add_runtime_dependency 'inch', '~> 0.8'
   spec.add_runtime_dependency 'rake'
 end

--- a/inch_by_inch.gemspec
+++ b/inch_by_inch.gemspec
@@ -20,8 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_runtime_dependency 'inch', '~> 0.8.0'
-  spec.add_runtime_dependency 'rake', '~> 10.0'
-
-  spec.add_development_dependency 'bundler', '~> 1.11.pre'
+  spec.add_runtime_dependency 'inch', '~> 0.8'
+  spec.add_runtime_dependency 'rake'
 end

--- a/lib/inch_by_inch/rake_task.rb
+++ b/lib/inch_by_inch/rake_task.rb
@@ -25,7 +25,7 @@ module InchByInch
     private
 
     def install_task(task_name)
-      desc 'Lint the completeness of the documentation with Inch' unless ::Rake.application.last_comment
+      desc 'Lint the completeness of the documentation with Inch' unless ::Rake.application.last_description
       task(task_name) do
         require 'inch'
         require 'inch/cli'


### PR DESCRIPTION
I found CocoaPods sticking on `rake 10.0`, so I'm trying to loosen the constraint, should be no harm